### PR TITLE
LinkedBlockingQueue实现的可关闭队列

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueueTest.java
@@ -48,7 +48,7 @@ public class ClosableBlockingQueueTest {
 	public void testCreateQueueHashCodeEquals() {
 		try {
 			ClosableBlockingQueue<String> queue1 = new ClosableBlockingQueue<>();
-			ClosableBlockingQueue<String> queue2 = new ClosableBlockingQueue<>(22);
+			ClosableBlockingQueue<String> queue2 = new ClosableBlockingQueue<>();
 
 			assertTrue(queue1.isOpen());
 			assertTrue(queue2.isOpen());


### PR DESCRIPTION
基本思路是利用LinkedBlockingQueue的并发和线程调度；批量操作由单个原子操作“拼接”而成；


TODO：单测没通过。